### PR TITLE
Fixup code for riscv64

### DIFF
--- a/asciigraph.go
+++ b/asciigraph.go
@@ -29,7 +29,7 @@ func Plot(series []float64, options ...Option) string {
 	interval := math.Abs(maximum - minimum)
 
 	if config.Height <= 0 {
-		if int(interval) <= 0 {
+		if interval != 0 && int(interval) <= 0 {
 			config.Height = int(interval * math.Pow10(int(math.Ceil(-math.Log10(interval)))))
 		} else {
 			config.Height = int(interval)


### PR DESCRIPTION
When the value of interval is exactly 0, the log of 10 followed by pow can give unpredictable results based on the arch since we are dealing with Inf here.

Since it should normally be just zero, assign it such.

Fixes the build on riscv64:
```
go test -vet=off -v -p 4
=== RUN   TestPlot
=== RUN   TestPlot/0
--- FAIL: TestPlot (0.00s)
    --- FAIL: TestPlot/0 (0.00s)
panic: runtime error: index out of range [9223372036854775807] with length 0 [recovered]
	panic: runtime error: index out of range [9223372036854775807] with length 0

goroutine 7 [running]:
testing.tRunner.func1.2({0x139280, 0x3f50012078})
	/usr/lib/go-1.22/src/testing/testing.go:1631 +0x1e0
testing.tRunner.func1()
	/usr/lib/go-1.22/src/testing/testing.go:1634 +0x2cc
panic({0x139280?, 0x3f50012078?})
	/usr/lib/go-1.22/src/runtime/panic.go:770 +0x108
int.Plot({0x3f50014060, 0x5, 0x5}, {0x0, 0x0, 0x21ef18?})
	/home/nilesh/lazygit/golang-github-jesseduffield-asciigraph/asciigraph.go:122 +0xe74
int.TestPlot.func1(0x3f50112680)
	/home/nilesh/lazygit/golang-github-jesseduffield-asciigraph/asciigraph_test.go:240 +0x68
testing.tRunner(0x3f50112680, 0x3f50070450)
	/usr/lib/go-1.22/src/testing/testing.go:1689 +0x108
created by testing.(*T).Run in goroutine 6
	/usr/lib/go-1.22/src/testing/testing.go:1742 +0x348
exit status 2
FAIL	int	0.027s
```